### PR TITLE
Fix: Arrumando import do componente Button

### DIFF
--- a/src/views/LandingPage/LadingPage.tsx
+++ b/src/views/LandingPage/LadingPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from "../../components/Button/button";
+import { Button } from "../../Components/Button/button";
 import { ContainerFooter, ContainerHeader, ContainerList, ContainerPage, IconSignIn, IconSignUp, Navbar } from "./style";
 import LandingPageImg from "../../assets/landing-page.png"
 import LandingPageImgMobile from "../../assets/landing-page-mobile.png"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7334,7 +7334,6 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-<<<<<<< HEAD
 react-fast-compare@^2.0.1:
   version "2.0.4"
   resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz"
@@ -7342,12 +7341,7 @@ react-fast-compare@^2.0.1:
 
 react-icons@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz"
-=======
-react-icons@^4.4.0:
-  version "4.4.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
->>>>>>> feat/landingpage
   integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
 
 react-is@^16.13.1, react-is@^16.7.0:


### PR DESCRIPTION
O import do Button na página LangingPage está escrito da seguinte forma:
`import { Button } from "../../components/Button/button";` 
quando na verdade deveria ser escrito assim:
`import { Button } from "../../Components/Button/button";`
